### PR TITLE
Update prose to match the chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The following results were obtained on a Mac Mini M1, 2020 with 8 cores (4 perfo
 
 ![Primes in First 100000000 Numbers](img/bar_plot__100000000_.png)
 
-Shown from left to right are execution times for sieve implementations using concurrencpp, libunifex, TBB, direct function calls, and std::async.  These results were obtained with a block size of 100k numbers.  Each bar shows mean and standard deviation over a total of 16 runs for each implementation.
+Shown from left to right are execution times for sieve implementations using wg21_p2300_std_async, concurrencpp, libunifex, TBB, direct function calls, and std::async.  These results were obtained with a block size of 100k numbers.  Each bar shows mean and standard deviation over a total of 16 runs for each implementation.
 
 ### Primes less than 1'000'000'000
 


### PR DESCRIPTION
The prose neglected to mention wg21_p2300_std_async.